### PR TITLE
Add python 3.9 and 3.10 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,7 +58,7 @@ jobs:
             command: test
 
         - name: Set up Python ${{ matrix.python-version }}
-          uses: actions/setup-python@v1
+          uses: actions/setup-python@v2
           with:
             python-version: ${{ matrix.python-version }}
 
@@ -93,7 +93,7 @@ jobs:
             command: test
 
         - name: Set up Python ${{ matrix.python-version }}
-          uses: actions/setup-python@v1
+          uses: actions/setup-python@v2
           with:
             python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
       strategy:
         fail-fast: false
         matrix:
-          python-version: [3.6, 3.7, 3.8]
+          python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
           os: [ubuntu-latest, macos-latest, windows-latest]
 
       steps:
@@ -77,7 +77,7 @@ jobs:
       strategy:
         fail-fast: false
         matrix:
-          python-version: [3.6, 3.7, 3.8]
+          python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
           os: [ubuntu-latest, macos-latest, windows-latest]
 
       steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
       strategy:
         fail-fast: false
         matrix:
-          python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
+          python-version: [3.6, 3.7, 3.8, 3.9, 3.10.0]
           os: [ubuntu-latest, macos-latest, windows-latest]
 
       steps:
@@ -77,7 +77,7 @@ jobs:
       strategy:
         fail-fast: false
         matrix:
-          python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
+          python-version: [3.6, 3.7, 3.8, 3.9, 3.10.0]
           os: [ubuntu-latest, macos-latest, windows-latest]
 
       steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ classifier = [
   "Programming Language :: Python :: 3.6",
   "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
 ]
 
 [lib]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-pytest==5.3.*
+pytest==6.2.*
 maturin==0.8.*
 eth-utils==1.9.*
 rlp==1.2.*


### PR DESCRIPTION
I'm not sure if this is how I should go about adding python 3.9 and 3.10 support, so let me know if there is anything else I need to do. I need to add this because when I add python3.9 support to pyrlp, pip is unable to find this dependency. [Here's a link to the failure](https://app.circleci.com/pipelines/github/ethereum/pyrlp/104/workflows/c5d36a3d-ceec-40cb-8865-605f495c7ad2/jobs/815) on CI if you're curious.

EDIT: Also looks like I need approval before running a workflow. Thanks!