### PR TITLE
Remove python 3.5 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
       strategy:
         fail-fast: false
         matrix:
-          python-version: [3.5, 3.6, 3.7, 3.8]
+          python-version: [3.6, 3.7, 3.8]
           os: [ubuntu-latest, macos-latest, windows-latest]
 
       steps:
@@ -77,7 +77,7 @@ jobs:
       strategy:
         fail-fast: false
         matrix:
-          python-version: [3.5, 3.6, 3.7, 3.8]
+          python-version: [3.6, 3.7, 3.8]
           os: [ubuntu-latest, macos-latest, windows-latest]
 
       steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ classifier = [
   "License :: OSI Approved :: MIT License",
   "Natural Language :: English",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.5",
   "Programming Language :: Python :: 3.6",
   "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",


### PR DESCRIPTION
Python 3.5 is no longer supported as of 2020, so while I'm here, I figured I'd remove it. I think I still need permissions to run the workflow though. 