### PR TITLE
drop py36 and py37 support, add py311

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
       strategy:
         fail-fast: false
         matrix:
-          python-version: [3.6, 3.7, 3.8, 3.9, 3.10.0]
+          python-version: [3.8, 3.9, 3.10, 3.11]
           os: [ubuntu-latest, macos-latest, windows-latest]
 
       steps:
@@ -77,7 +77,7 @@ jobs:
       strategy:
         fail-fast: false
         matrix:
-          python-version: [3.6, 3.7, 3.8, 3.9, 3.10.0]
+          python-version: [3.8, 3.9, 3.10, 3.11]
           os: [ubuntu-latest, macos-latest, windows-latest]
 
       steps:

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 .vscode
 venv
 __pycache__
+
+.python-version

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,10 @@ classifier = [
   "License :: OSI Approved :: MIT License",
   "Natural Language :: English",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.6",
-  "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
 ]
 
 [lib]


### PR DESCRIPTION
I'm looking to add py311 support to `pyrlp` and it appears I need 311 support here first. I tried add 3.12 too, but it looks like `eth-utils` needs some updates first.

If there's anything else to do to prepare a release, let me know!